### PR TITLE
Attachment support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,9 @@ jobs:
         path: |
           .build
           Package.resolved
-        key: ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('**/Package.resolved') }}
+        key: ${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('Package.resolved') }}
         restore-keys: |
-          ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-
+          ${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-
     - name: Resolve dependencies
       if: steps.cache-resolved-dependencies.outputs.cache-hit != 'true'
       run: ${{ env.swift_package_resolve }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,10 @@ jobs:
         include:
           - swift: nightly-5.5
             container: "swiftlang/swift:nightly-5.5-focal"
-            cache-version: 2
           - swift: "5.4"
             container: "swift:5.4"
-            cache-version: 2
           - swift: "5.3"
             container: "swift:5.3"
-            cache-version: 1
     runs-on: ubuntu-20.04
     container: ${{ matrix.container }}
     name: Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,12 +79,12 @@ jobs:
     - uses: actions/checkout@master
     - name: Cache resolved dependencies
       id: cache-resolved-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           .build
           Package.resolved
-        key: ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('**/Package.swift', '**/Package.resolved') }}
+        key: ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('**/Package.resolved') }}
         restore-keys: |
           ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-
     - name: Resolve dependencies

--- a/Sources/SwiftSentry/Envelope.swift
+++ b/Sources/SwiftSentry/Envelope.swift
@@ -1,0 +1,223 @@
+import Foundation
+import NIOCore
+
+public enum EnvelopItemTypes: String {
+    case event
+    case transaction
+    case attachment
+    case session
+    case sessions
+    case user_report
+    case client_report
+}
+
+public enum NewlineData {
+    static let newlineData = "\n".data(using: String.Encoding.utf8)!
+}
+
+public struct Envelope {
+    enum EnvelopeError: Error {
+        case TooManyErrorsOrTransactions(count: UInt64)
+        case ItemsRequireEventIdButNoEventIdInEnvelopHeader
+        case EnvelopeToLarge(size: UInt64)
+    }
+
+    public var header: EnvelopeHeader
+    public var items: [EnvelopeItem]
+    public init(header: EnvelopeHeader, items: [EnvelopeItem]) {
+        self.header = header
+        self.items = items
+    }
+
+    public func dump(encoder: JSONEncoder) throws -> Data {
+        var event_transaction_count: UInt64 = 0
+        var req_event_id: UInt64 = 0
+        var returnData = try encoder.encode(header) + NewlineData.newlineData
+        returnData.append(try items
+            .map {
+                if $0.header.type == "transaction" || $0.header.type == "event" {
+                    event_transaction_count += 1
+                } else if $0.header.type == "user_report" || $0.header.type == "attachment" {
+                    req_event_id += 1
+                }
+                return try $0.dump(encoder: encoder)
+            }
+            .reduce(into: Data()) { acu, adi in
+                acu.append(adi)
+            })
+        if event_transaction_count >= 2 {
+            throw EnvelopeError.TooManyErrorsOrTransactions(count: event_transaction_count)
+        }
+        if (req_event_id + event_transaction_count) > 0, header.eventId == nil {
+            throw EnvelopeError.ItemsRequireEventIdButNoEventIdInEnvelopHeader
+        }
+        if returnData.count > Sentry.maxEnvelopeUncompressedSize {
+            throw EnvelopeError.EnvelopeToLarge(size: UInt64(returnData.count))
+        }
+        return returnData
+    }
+}
+
+public struct EnvelopeHeader: Codable {
+    public static let RFC3339DateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return dateFormatter
+    }()
+
+    public var eventId: UUID?
+    public var dsn: String?
+    public var sdk: String?
+    public var sentAt: String = ""
+    public init(eventId: UUID?, dsn: String?, sdk: String?) {
+        self.eventId = eventId
+        self.dsn = dsn
+        self.sdk = sdk
+    }
+
+    public enum CodingKeys: String, CodingKey {
+        case eventId = "event_id"
+        case dsn
+        case sdk
+        case sentAt = "sent_at"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder
+            .container(keyedBy: CodingKeys.self)
+        if eventId != nil {
+            try container.encode(eventId, forKey: .init(stringValue: "event_id")!)
+        }
+        if dsn != nil {
+            try container.encode(dsn, forKey: .init(stringValue: "dsn")!)
+        }
+        if sdk != nil {
+            try container.encode(sdk, forKey: .init(stringValue: "sdk")!)
+        }
+        try container.encode(EnvelopeHeader.RFC3339DateFormatter.string(from: Date()), forKey: .init(stringValue: "sent_at")!)
+    }
+}
+
+public struct EnvelopeItemHeader: Codable {
+    public var type: String
+    public var length: UInt64
+    public var filename: String?
+    public var contentType: String?
+    public init(type: String, length: UInt64, filename: String?, contentType: String?) {
+        self.type = type
+        self.length = length
+        self.filename = filename
+        self.contentType = contentType
+    }
+
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case length
+        case filename
+        case contentType = "content_type"
+    }
+}
+
+public struct EnvelopeItem {
+    public enum EnvelopeItemError: Error {
+        case AttachmentToLarge(size: UInt64)
+        case EventOrAttachmentToLarge(size: UInt64)
+        case SizeMissmatch(givenSize: UInt64, actualSize: UInt64)
+    }
+
+    public var header: EnvelopeItemHeader
+    public var data: Data
+    public init(header: EnvelopeItemHeader, data: Data) throws {
+        if header.length != UInt64(data.count) {
+            throw EnvelopeItemError.SizeMissmatch(givenSize: header.length, actualSize: UInt64(data.count))
+        }
+        self.header = header
+        self.data = data
+    }
+
+    public func dumpToString(encoder: JSONEncoder) throws -> String {
+        let headerData = try encoder.encode(header)
+        let returnString = String(data: headerData, encoding: String.Encoding.utf8)! + "\n" + String(data: data, encoding: String.Encoding.utf8)! + "\n"
+        if header.type == "attachment", (headerData.count + 2 + data.count) > Sentry.maxEachAtachment {
+            throw EnvelopeItemError.AttachmentToLarge(size: UInt64(headerData.count + 2 + data.count))
+        }
+        if !(header.type != "event" && header.type != "transaction"), (headerData.count + 2 + data.count) > Sentry.maxEventAndTransaction {
+            throw EnvelopeItemError.EventOrAttachmentToLarge(size: UInt64(headerData.count + 2 + data.count))
+        }
+        return returnString
+    }
+
+    public func dump(encoder: JSONEncoder) throws -> Data {
+        let returnData = try encoder.encode(header) + NewlineData.newlineData + data + NewlineData.newlineData
+        assert(header.type != "attachment" || returnData.count <= Sentry.maxEachAtachment)
+        assert((header.type != "event" && header.type != "transaction") || returnData.count <= Sentry.maxEventAndTransaction)
+        return returnData
+    }
+}
+
+public struct Attachment {
+    public enum AttachmentError: Error {
+        case NoDataOrFilenameOrPath
+        case FileReadFailed
+    }
+
+    public static let defaultContentType = "application/octet-stream"
+    public var filename: String
+    public var payload: AttachmentPayload
+    public var contentType: String
+    public func toEnvelopeItem() throws -> EnvelopeItem {
+        var tempData = try payload.dump()
+        if tempData.count > Sentry.maxAttachmentSize {
+            tempData.removeAll()
+        }
+        return try EnvelopeItem(header: EnvelopeItemHeader(type: "attachment", length: UInt64(tempData.count), filename: filename, contentType: contentType), data: tempData)
+    }
+
+    public init(data: Data, filename: String, contentType: String = Attachment.defaultContentType) {
+        self.filename = filename
+        payload = .fromPayload(data)
+        self.contentType = contentType
+    }
+
+    public init(path: String, filename: String? = nil, contentType: String = Attachment.defaultContentType) throws {
+        var path = path
+        if let filename = filename {
+            self.filename = filename
+        } else {
+            let tmep = path.components(separatedBy: "/")
+            guard let filename = tmep.last else {
+                throw AttachmentError.NoDataOrFilenameOrPath
+            }
+            self.filename = filename
+            path = tmep.dropLast().joined(separator: "/")
+        }
+
+        payload = .fromFile(path, self.filename)
+        self.contentType = contentType
+    }
+
+    public init(path: String, filenameNN: String, contentType: String = Attachment.defaultContentType) {
+        filename = filenameNN
+        payload = .fromFile(path, filename)
+        self.contentType = contentType
+    }
+
+    public enum AttachmentPayload {
+        case fromPayload(Data)
+        case fromFile(String?, String)
+        public func dump() throws -> Data {
+            switch self {
+            case let .fromFile(path, filename):
+                do {
+                    return try Data(contentsOf: URL(fileURLWithPath: (path ?? "") + filename))
+                } catch {
+                    throw AttachmentError.FileReadFailed
+                }
+            case let .fromPayload(data):
+                return data
+            }
+        }
+    }
+}

--- a/Sources/SwiftSentry/Envelope.swift
+++ b/Sources/SwiftSentry/Envelope.swift
@@ -88,15 +88,15 @@ public struct EnvelopeHeader: Codable {
         var container = encoder
             .container(keyedBy: CodingKeys.self)
         if eventId != nil {
-            try container.encode(eventId, forKey: .init(stringValue: "event_id")!)
+            try container.encode(eventId, forKey: CodingKeys.eventId)
         }
         if dsn != nil {
-            try container.encode(dsn, forKey: .init(stringValue: "dsn")!)
+            try container.encode(dsn, forKey: CodingKeys.dsn)
         }
         if sdk != nil {
-            try container.encode(sdk, forKey: .init(stringValue: "sdk")!)
+            try container.encode(sdk, forKey: CodingKeys.sdk)
         }
-        try container.encode(EnvelopeHeader.RFC3339DateFormatter.string(from: Date()), forKey: .init(stringValue: "sent_at")!)
+        try container.encode(EnvelopeHeader.RFC3339DateFormatter.string(from: Date()), forKey: CodingKeys.sentAt)
     }
 }
 

--- a/Sources/SwiftSentry/Envelope.swift
+++ b/Sources/SwiftSentry/Envelope.swift
@@ -42,7 +42,7 @@ public struct Envelope {
             throw EnvelopeError.tooManyErrorsOrTransactions(count: eventTransactionCount)
             // Envelope may contain at most one error or one transaction item
         }
-        guard (itemsReqEventIdCount + eventTransactionCount) == 0 && header.eventId != nil else {
+        guard (itemsReqEventIdCount + eventTransactionCount) == 0 || header.eventId != nil else {
             throw EnvelopeError.eventIdRequiredButNotPresentInEnvelope
         }
     }

--- a/Sources/SwiftSentry/Envelope.swift
+++ b/Sources/SwiftSentry/Envelope.swift
@@ -150,158 +150,75 @@ public struct EnvelopeItem {
     }
 }
 
-#if swift(>=5.7)
-    public struct Attachment: CustomStringConvertible, Sendable {
-        public enum AttachmentError: Error {
-            case NoDataOrFilenameOrPath
-            case FileReadFailed
-        }
+public struct Attachment: Sendable {
+    public enum AttachmentError: Error {
+        case NoDataOrFilenameOrPath
+        case FileReadFailed
+    }
 
-        public var description: String {
-            "Attachment: \(filename)"
+    public static let defaultContentType = "application/octet-stream"
+    public var filename: String
+    public var payload: AttachmentPayload
+    public var contentType: String
+    public func toEnvelopeItem() throws -> EnvelopeItem {
+        var tempData = try payload.dump()
+        if tempData.count > Sentry.maxAttachmentSize {
+            tempData.removeAll()
         }
+        return EnvelopeItem(header: EnvelopeItemHeader(type: "attachment", length: UInt64(tempData.count), filename: filename, contentType: contentType), data: tempData)
+    }
 
-        public static let defaultContentType = "application/octet-stream"
-        public var filename: String
-        public var payload: AttachmentPayload
-        public var contentType: String
-        public func toEnvelopeItem() throws -> EnvelopeItem {
-            var tempData = try payload.dump()
-            if tempData.count > Sentry.maxAttachmentSize {
-                tempData.removeAll()
-            }
-            return EnvelopeItem(header: EnvelopeItemHeader(type: "attachment", length: UInt64(tempData.count), filename: filename, contentType: contentType), data: tempData)
+    public func toEnvelopeItemNoThrow() -> EnvelopeItem? {
+        do {
+            return try toEnvelopeItem()
+        } catch {
+            return nil
         }
+    }
 
-        public func toEnvelopeItemNoThrow() -> EnvelopeItem? {
-            do {
-                return try toEnvelopeItem()
-            } catch {
-                return nil
-            }
-        }
+    public init(data: Data, filename: String, contentType: String = Attachment.defaultContentType) {
+        self.filename = filename
+        payload = .fromPayload([UInt8](data))
+        self.contentType = contentType
+    }
 
-        public init(data: Data, filename: String, contentType: String = Attachment.defaultContentType) {
+    public init(path: String, filename: String? = nil, contentType: String = Attachment.defaultContentType) throws {
+        var path = path
+        if let filename = filename {
             self.filename = filename
-            payload = .fromPayload([UInt8](data))
-            self.contentType = contentType
-        }
-
-        public init(path: String, filename: String? = nil, contentType: String = Attachment.defaultContentType) throws {
-            var path = path
-            if let filename = filename {
-                self.filename = filename
-            } else {
-                let tmep = path.components(separatedBy: "/")
-                guard let filename = tmep.last else {
-                    throw AttachmentError.NoDataOrFilenameOrPath
-                }
-                self.filename = filename
-                path = tmep.dropLast().joined(separator: "/")
+        } else {
+            let tmep = path.components(separatedBy: "/")
+            guard let filename = tmep.last else {
+                throw AttachmentError.NoDataOrFilenameOrPath
             }
-
-            payload = .fromFile(path, self.filename)
-            self.contentType = contentType
-        }
-
-        public init(path: String? = nil, filename: String, contentType: String = Attachment.defaultContentType) {
             self.filename = filename
-            payload = .fromFile(path, filename)
-            self.contentType = contentType
+            path = tmep.dropLast().joined(separator: "/")
         }
 
-        public enum AttachmentPayload: Sendable {
-            case fromPayload([UInt8])
-            case fromFile(String?, String)
-            public func dump() throws -> Data {
-                switch self {
-                case let .fromFile(path, filename):
-                    do {
-                        return try Data(contentsOf: URL(fileURLWithPath: (path ?? "") + filename))
-                    } catch {
-                        throw AttachmentError.FileReadFailed
-                    }
-                case let .fromPayload(data):
-                    return Data(data)
+        payload = .fromFile(path, self.filename)
+        self.contentType = contentType
+    }
+
+    public init(path: String? = nil, filename: String, contentType: String = Attachment.defaultContentType) {
+        self.filename = filename
+        payload = .fromFile(path, filename)
+        self.contentType = contentType
+    }
+
+    public enum AttachmentPayload: Sendable {
+        case fromPayload([UInt8])
+        case fromFile(String?, String)
+        public func dump() throws -> Data {
+            switch self {
+            case let .fromFile(path, filename):
+                do {
+                    return try Data(contentsOf: URL(fileURLWithPath: (path ?? "") + filename))
+                } catch {
+                    throw AttachmentError.FileReadFailed
                 }
+            case let .fromPayload(data):
+                return Data(data)
             }
         }
     }
-#else
-    public struct Attachment: CustomStringConvertible {
-        public enum AttachmentError: Error {
-            case NoDataOrFilenameOrPath
-            case FileReadFailed
-        }
-
-        public var description: String {
-            "Attachment: \(filename)"
-        }
-
-        public static let defaultContentType = "application/octet-stream"
-        public var filename: String
-        public var payload: AttachmentPayload
-        public var contentType: String
-        public func toEnvelopeItem() throws -> EnvelopeItem {
-            var tempData = try payload.dump()
-            if tempData.count > Sentry.maxAttachmentSize {
-                tempData.removeAll()
-            }
-            return EnvelopeItem(header: EnvelopeItemHeader(type: "attachment", length: UInt64(tempData.count), filename: filename, contentType: contentType), data: tempData)
-        }
-
-        public func toEnvelopeItemNoThrow() -> EnvelopeItem? {
-            do {
-                return try toEnvelopeItem()
-            } catch {
-                return nil
-            }
-        }
-
-        public init(data: Data, filename: String, contentType: String = Attachment.defaultContentType) {
-            self.filename = filename
-            payload = .fromPayload(data)
-            self.contentType = contentType
-        }
-
-        public init(path: String, filename: String? = nil, contentType: String = Attachment.defaultContentType) throws {
-            var path = path
-            if let filename = filename {
-                self.filename = filename
-            } else {
-                let tmep = path.components(separatedBy: "/")
-                guard let filename = tmep.last else {
-                    throw AttachmentError.NoDataOrFilenameOrPath
-                }
-                self.filename = filename
-                path = tmep.dropLast().joined(separator: "/")
-            }
-
-            payload = .fromFile(path, self.filename)
-            self.contentType = contentType
-        }
-
-        public init(path: String? = nil, filename: String, contentType: String = Attachment.defaultContentType) {
-            self.filename = filename
-            payload = .fromFile(path, filename)
-            self.contentType = contentType
-        }
-
-        public enum AttachmentPayload {
-            case fromPayload(Data)
-            case fromFile(String?, String)
-            public func dump() throws -> Data {
-                switch self {
-                case let .fromFile(path, filename):
-                    do {
-                        return try Data(contentsOf: URL(fileURLWithPath: (path ?? "") + filename))
-                    } catch {
-                        throw AttachmentError.FileReadFailed
-                    }
-                case let .fromPayload(data):
-                    return data
-                }
-            }
-        }
-    }
-#endif
+}

--- a/Sources/SwiftSentry/Envelope.swift
+++ b/Sources/SwiftSentry/Envelope.swift
@@ -150,7 +150,7 @@ public struct EnvelopeItem {
     }
 }
 
-public struct Attachment: Sendable {
+public struct Attachment {
     public enum AttachmentError: Error {
         case NoDataOrFilenameOrPath
         case FileReadFailed
@@ -205,7 +205,7 @@ public struct Attachment: Sendable {
         self.contentType = contentType
     }
 
-    public enum AttachmentPayload: Sendable {
+    public enum AttachmentPayload {
         case fromPayload([UInt8])
         case fromFile(String?, String)
         public func dump() throws -> Data {
@@ -222,3 +222,9 @@ public struct Attachment: Sendable {
         }
     }
 }
+
+#if swift(>=5.5)
+    extension Attachment.AttachmentPayload: Sendable {}
+
+    extension Attachment: Sendable {}
+#endif

--- a/Sources/SwiftSentry/Envelope.swift
+++ b/Sources/SwiftSentry/Envelope.swift
@@ -240,9 +240,3 @@ public struct Attachment: CustomStringConvertible {
         }
     }
 }
-
-#if swift(>=5.5)
-    extension Attachment.AttachmentPayload: Sendable {}
-
-    extension Attachment: Sendable {}
-#endif

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -44,3 +44,9 @@ public func makeEventData(
         user: nil
     ))
 }
+
+extension Attachment: CustomStringConvertible {
+    public var description: String {
+        "Attachment: \(filename)"
+    }
+}

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -1,74 +1,52 @@
 import Foundation
 import Logging
 
-public struct LimitedEvent: Encodable {
-    @UUIDHexadecimalEncoded
-    var event_id: UUID
-
-    /// Platform identifier of this event (defaults to "other").
-    /// A string representing the platform the SDK is submitting from. This will be used by the Sentry interface to customize various components in the interface.
-    /// Acceptable values are: `as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `haskell`, `go`, `groovy`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`, `ruby`
-    let platform: String = "other"
-
-    /// The record severity. Defaults to `error`.
-    let level: Level?
-
-    /// The name of the logger which created the record.
-    let logger: String?
-
-    /// The name of the transaction which caused this exception.
-    /// For example, in a web app, this might be the route name.
-    let transaction: String?
-
-    /// Server or device name the event was generated on.
-    /// This is supposed to be a hostname.
-    let server_name: String?
-
-    /// The release version of the application. Release versions must be unique across all projects in your organization.
-    let release: String?
-
-    /// Optional. A map or list of tags for this event. Each tag must be less than 200 characters.
-    let tags: [String: String]?
-
-    /// The environment name, such as `production` or `staging`.
-    let environment: String?
-
-    /// The Message Interface carries a log message that describes an event or error.
-    let message: Message?
-
-    /// One or multiple chained (nested) exceptions.
-    let exception: Exceptions?
-}
-
 public func evalMetadata(metadata: Logger.Metadata) -> Attachment? {
-    if let filenameValue = metadata["AttachmentFileName"],
-       case let .string(filename) = filenameValue
+    if let attachmentValue = metadata["Attachment"],
+       case let .stringConvertible(attachmentCon) = attachmentValue,
+       let attachment: Attachment = attachmentCon as? Attachment
     {
-        if let attachmentDataValue = metadata["AttachmentData"],
-           case let .stringConvertible(dataCon) = attachmentDataValue,
-           let data: Data = dataCon as? Data
-        {
-            return .init(data: data, filename: filename)
-        }
-        if let attachmentPathValue = metadata["AttachmentPath"],
-           case let .string(path) = attachmentPathValue
-        {
-            do {
-                return try .init(path: path, filename: filename)
-            } catch {
-                return nil
-            }
-        }
-    }
-
-    if let attachmentPathValue = metadata["AttachmentPath"],
-       case let .string(path) = attachmentPathValue
-    {
-        do {
-            return try .init(path: path)
-        } catch {
-            return nil
-        }
+        return attachment
     }
     return nil
+}
+
+public func makeEventData(
+    message: String,
+    level: Level,
+    uid: UUID,
+    servername: String?,
+    release: String?,
+    environment: String?,
+    logger: String? = nil,
+    transaction: String? = nil,
+    tags: [String: String]? = nil,
+    filePath: String? = #filePath,
+    file: String?,
+    function: String? = #function,
+    line: Int? = #line
+) throws -> Data {
+    let frame = Frame(filename: file, function: function, raw_function: nil, lineno: line, colno: nil, abs_path: filePath, instruction_addr: nil)
+    let stacktrace = Stacktrace(frames: [frame])
+    return try JSONEncoder().encode(Event(
+        event_id: uid,
+        timestamp: Date().timeIntervalSince1970,
+        level: level,
+        logger: logger,
+        transaction: transaction,
+        server_name: servername,
+        release: release,
+        tags: tags,
+        environment: environment,
+        message: .raw(message: message),
+        exception: Exceptions(values: [ExceptionDataBag(type: message, value: nil, stacktrace: stacktrace)]),
+        breadcrumbs: nil,
+        user: nil
+    ))
+}
+
+extension Attachment: CustomStringConvertible {
+    public var description: String {
+        "Attachment: \(filename)"
+    }
 }

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -44,9 +44,3 @@ public func makeEventData(
         user: nil
     ))
 }
-
-extension Attachment: CustomStringConvertible {
-    public var description: String {
-        "Attachment: \(filename)"
-    }
-}

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Logging
 
-public func evalMetadata(metadata: Logger.Metadata) -> Attachment? {
-    if let attachmentValue = metadata["Attachment"],
+public func evalMetadata(metadata: Logger.Metadata, attachmentKey: String) -> Attachment? {
+    if let attachmentValue = metadata[attachmentKey],
        case let .stringConvertible(attachmentCon) = attachmentValue,
        let attachment: Attachment = attachmentCon as? Attachment
     {

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Logging
+
+public struct LimitedEvent: Encodable {
+    @UUIDHexadecimalEncoded
+    var event_id: UUID
+
+    /// Platform identifier of this event (defaults to "other").
+    /// A string representing the platform the SDK is submitting from. This will be used by the Sentry interface to customize various components in the interface.
+    /// Acceptable values are: `as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `haskell`, `go`, `groovy`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`, `ruby`
+    let platform: String = "other"
+
+    /// The record severity. Defaults to `error`.
+    let level: Level?
+
+    /// The name of the logger which created the record.
+    let logger: String?
+
+    /// The name of the transaction which caused this exception.
+    /// For example, in a web app, this might be the route name.
+    let transaction: String?
+
+    /// Server or device name the event was generated on.
+    /// This is supposed to be a hostname.
+    let server_name: String?
+
+    /// The release version of the application. Release versions must be unique across all projects in your organization.
+    let release: String?
+
+    /// Optional. A map or list of tags for this event. Each tag must be less than 200 characters.
+    let tags: [String: String]?
+
+    /// The environment name, such as `production` or `staging`.
+    let environment: String?
+
+    /// The Message Interface carries a log message that describes an event or error.
+    let message: Message?
+
+    /// One or multiple chained (nested) exceptions.
+    let exception: Exceptions?
+}
+
+public func evalMetadata(metadata: Logger.Metadata) -> Attachment? {
+    if let filenameValue = metadata["AttachmentFileName"],
+       case let .string(filename) = filenameValue
+    {
+        if let attachmentDataValue = metadata["AttachmentData"],
+           case let .stringConvertible(dataCon) = attachmentDataValue,
+           let data: Data = dataCon as? Data
+        {
+            return .init(data: data, filename: filename)
+        }
+        if let attachmentPathValue = metadata["AttachmentPath"],
+           case let .string(path) = attachmentPathValue
+        {
+            do {
+                return try .init(path: path, filename: filename)
+            } catch {
+                return nil
+            }
+        }
+    }
+
+    if let attachmentPathValue = metadata["AttachmentPath"],
+       case let .string(path) = attachmentPathValue
+    {
+        do {
+            return try .init(path: path)
+        } catch {
+            return nil
+        }
+    }
+    return nil
+}

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -1,20 +1,21 @@
 import Foundation
 import Logging
 
-// Check Wether there is an Attachment in the Logger.Metadata with the specified attachment Key
-// If the specified AttachmentKey is nil or it has no value or the value can't be converted to
-// an attachement, nil will be returned
+/// Check Wether there is an Attachment in the Logger.Metadata with the specified attachment Key
+/// If the specified AttachmentKey is nil or it has no value or the value can't be converted to
+/// an attachement, nil will be returned
 public func evalMetadata(metadata: Logger.Metadata, attachmentKey: String?) -> Attachment? {
     if let attachmentKey = attachmentKey,
-       let attachmentValue = metadata[attachmentKey],
-       case let .stringConvertible(attachmentCon) = attachmentValue,
-       let attachment: Attachment = attachmentCon as? Attachment
+        let attachmentValue = metadata[attachmentKey],
+        case let .stringConvertible(attachmentCon) = attachmentValue,
+        let attachment: Attachment = attachmentCon as? Attachment
     {
         return attachment
     }
     return nil
 }
 
+/// Construct an Envent, encode it to JSONData, return that data
 public func makeEventData(
     message: String,
     level: Level,
@@ -26,25 +27,35 @@ public func makeEventData(
     transaction: String? = nil,
     tags: [String: String]? = nil,
     filePath: String? = #filePath,
-    file: String?,
+    file: String? = #file,
     function: String? = #function,
     line: Int? = #line
 ) throws -> Data {
-    let frame = Frame(filename: file, function: function, raw_function: nil, lineno: line, colno: nil, abs_path: filePath, instruction_addr: nil)
+    let frame = Frame(
+        filename: file,
+        function: function,
+        raw_function: nil,
+        lineno: line,
+        colno: nil,
+        abs_path: filePath,
+        instruction_addr: nil
+    )
     let stacktrace = Stacktrace(frames: [frame])
-    return try JSONEncoder().encode(Event(
-        event_id: uid,
-        timestamp: Date().timeIntervalSince1970,
-        level: level,
-        logger: logger,
-        transaction: transaction,
-        server_name: servername,
-        release: release,
-        tags: tags,
-        environment: environment,
-        message: .raw(message: message),
-        exception: Exceptions(values: [ExceptionDataBag(type: message, value: nil, stacktrace: stacktrace)]),
-        breadcrumbs: nil,
-        user: nil
-    ))
+    return try JSONEncoder().encode(
+        Event(
+            event_id: uid,
+            timestamp: Date().timeIntervalSince1970,
+            level: level,
+            logger: logger,
+            transaction: transaction,
+            server_name: servername,
+            release: release,
+            tags: tags,
+            environment: environment,
+            message: .raw(message: message),
+            exception: Exceptions(values: [ExceptionDataBag(type: message, value: nil, stacktrace: stacktrace)]),
+            breadcrumbs: nil,
+            user: nil
+        )
+    )
 }

--- a/Sources/SwiftSentry/LoggerHelpFunctions.swift
+++ b/Sources/SwiftSentry/LoggerHelpFunctions.swift
@@ -1,8 +1,12 @@
 import Foundation
 import Logging
 
-public func evalMetadata(metadata: Logger.Metadata, attachmentKey: String) -> Attachment? {
-    if let attachmentValue = metadata[attachmentKey],
+// Check Wether there is an Attachment in the Logger.Metadata with the specified attachment Key
+// If the specified AttachmentKey is nil or it has no value or the value can't be converted to
+// an attachement, nil will be returned
+public func evalMetadata(metadata: Logger.Metadata, attachmentKey: String?) -> Attachment? {
+    if let attachmentKey = attachmentKey,
+       let attachmentValue = metadata[attachmentKey],
        case let .stringConvertible(attachmentCon) = attachmentValue,
        let attachment: Attachment = attachmentCon as? Attachment
     {
@@ -43,10 +47,4 @@ public func makeEventData(
         breadcrumbs: nil,
         user: nil
     ))
-}
-
-extension Attachment: CustomStringConvertible {
-    public var description: String {
-        "Attachment: \(filename)"
-    }
 }

--- a/Sources/SwiftSentry/Sentry.swift
+++ b/Sources/SwiftSentry/Sentry.swift
@@ -18,7 +18,9 @@ public struct Sentry {
     internal var servername: String?
     internal var release: String?
     internal var environment: String?
+    // This one can be changed, it's merely the default value
     internal static var maxAttachmentSize = 20_971_520
+    // These ones are set by Sentry
     internal static let maxEnvelopeCompressedSize = 20_000_000
     internal static let maxEnvelopeUncompressedSize = 100_000_000
     internal static let maxAllAtachmentsCombined = 100_000_000

--- a/Sources/SwiftSentry/SentryLogHandler.swift
+++ b/Sources/SwiftSentry/SentryLogHandler.swift
@@ -55,7 +55,7 @@ public struct SentryLogHandler: LogHandler {
                         header: .init(type: "event", filename: nil, contentType: "application/json"),
                         data: eventData
                     ),
-                    attachment.toEnvelopeItem(),
+                    attachment.toEnvelopeItemNoThrow(),
                 ].compactMap { $0 })
                 sentry.capture(envelope: envelope)
                 return

--- a/Sources/SwiftSentry/SentryLogHandler.swift
+++ b/Sources/SwiftSentry/SentryLogHandler.swift
@@ -6,7 +6,7 @@ public struct SentryLogHandler: LogHandler {
     private let sentry: Sentry
     public var metadata = Logger.Metadata()
     public var logLevel: Logger.Level
-    private let attachmentKey: String
+    private let attachmentKey: String?
 
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
         get {
@@ -17,7 +17,7 @@ public struct SentryLogHandler: LogHandler {
         }
     }
 
-    public init(label: String, sentry: Sentry, level: Logger.Level, attachmentKey: String = "Attachment") {
+    public init(label: String, sentry: Sentry, level: Logger.Level, attachmentKey: String? = "Attachment") {
         self.label = label
         self.sentry = sentry
         logLevel = level

--- a/Sources/SwiftSentry/SentryLogHandler.swift
+++ b/Sources/SwiftSentry/SentryLogHandler.swift
@@ -6,6 +6,7 @@ public struct SentryLogHandler: LogHandler {
     private let sentry: Sentry
     public var metadata = Logger.Metadata()
     public var logLevel: Logger.Level
+    private let attachmentKey: String
 
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
         get {
@@ -16,10 +17,11 @@ public struct SentryLogHandler: LogHandler {
         }
     }
 
-    public init(label: String, sentry: Sentry, level: Logger.Level) {
+    public init(label: String, sentry: Sentry, level: Logger.Level, attachmentKey: String = "Attachment") {
         self.label = label
         self.sentry = sentry
         logLevel = level
+        self.attachmentKey = attachmentKey
     }
 
     public func log(
@@ -33,7 +35,7 @@ public struct SentryLogHandler: LogHandler {
     ) {
         let metadataEscaped = metadata.map { $0.merging(self.metadata, uniquingKeysWith: { a, _ in a }) } ?? self.metadata
         let tags = metadataEscaped.mapValues { "\($0)" }
-        if let attachment = evalMetadata(metadata: metadataEscaped) {
+        if let attachment = evalMetadata(metadata: metadataEscaped, attachmentKey: attachmentKey) {
             let uid = UUID()
             do {
                 let eventData = try makeEventData(

--- a/Sources/SwiftSentry/SentryLogHandler.swift
+++ b/Sources/SwiftSentry/SentryLogHandler.swift
@@ -52,13 +52,16 @@ public struct SentryLogHandler: LogHandler {
                     function: function,
                     line: Int(line)
                 )
-                let envelope: Envelope = .init(header: .init(eventId: uid, dsn: nil, sdk: nil), items: [
-                    .init(
-                        header: .init(type: "event", filename: nil, contentType: "application/json"),
-                        data: eventData
-                    ),
-                    attachment.toEnvelopeItemNoThrow(),
-                ].compactMap { $0 })
+                let envelope: Envelope = .init(
+                    header: .init(eventId: uid, dsn: nil, sdk: nil),
+                    items: [
+                        .init(
+                            header: .init(type: "event", filename: nil, contentType: "application/json"),
+                            data: eventData
+                        ),
+                        try? attachment.toEnvelopeItem(),
+                    ].compactMap { $0 }
+                )
                 sentry.capture(envelope: envelope)
                 return
             } catch {}


### PR DESCRIPTION
Added Support for sending Attachments
both via Sentry.send(Envelope)
and via logging MetadataKeys:
1. AttachmentFileName
2. AttachmentData
3. AttachmentPath
Edit:
No longer the 3 Keys above, but one configurable Key at LogHandler initilization, which stores an Attachment
